### PR TITLE
Update background.js to fix metric search

### DIFF
--- a/Extension/background.js
+++ b/Extension/background.js
@@ -35,7 +35,7 @@ chrome.omnibox.onInputEntered.addListener(
                 var newURL = 'https://galaxy.epic.com/?#Search/searchWord=' + encodeURIComponent(trimAlligators(text.substring(6)));
                 break;
             case 'metric':
-                var newURL = 'https://datahandbook.epic.com/Search/Index?SearchWord=' + encodeURIComponent(trimAlligators(text.substring(6))) + 'type=4';
+                var newURL = 'https://datahandbook.epic.com/Search/Index?SearchWord=' + encodeURIComponent(trimAlligators(text.substring(6))) + '&type=4';
                 break;
             default:
                 var newURL = 'https://galaxy.epic.com/?#Search/searchWord=' + encodeURIComponent(trimAlligators(text));

--- a/Extension/manifest.json
+++ b/Extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Epic UserWeb Search",
   "description": "Type 'uw ' and your search term to instantly search the Epic UserWeb. 'uw sherlock ' searches Sherlock logs.",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "background": {
     "scripts": ["background.js"],
     "persistent": false


### PR DESCRIPTION
The suffix appended to metric search previously did not begin with '&'. This is a simple change to allow metric search to work properly.