### PR TITLE
Allow the build to complete even if the publish fails

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,5 +21,7 @@ steps:
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: drop'
 
+  continueOnError: true
+
 
 


### PR DESCRIPTION
The build fails if a user who is not a member of the Azure Project submits a pull request.  This will hopefully work around the issue, while @Microsoft fixes this issue:
https://github.com/Microsoft/azure-pipelines-tasks/issues/8732